### PR TITLE
Pin actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c46ce66fc01faa1b4db15cdae82f79 # v3
         with:
           go-version: '^1.19.0'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,6 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-latest
     steps:
-      - uses: francois2metz/steampipe-plugin-build-push-action@v0
+      - uses: francois2metz/steampipe-plugin-build-push-action@1bbcbf051ce210859a0e45cdea52ba41c4edd09a # v0
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Pin remaining unpinned action references to immutable commit SHAs for supply-chain security.

### Actions pinned
- `actions/checkout@v3` -> `f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `actions/setup-go@v3` -> `be3c94b385c46ce66fc01faa1b4db15cdae82f79`

### Intentionally left unpinned
- `francois2metz/steampipe-plugin-build-push-action@v0` in `release.yml` -- custom action; skipping SHA pin for now.