### PR TITLE
Fix incorrect SHA for actions/setup-go@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: actions/setup-go@be3c94b385c46ce66fc01faa1b4db15cdae82f79 # v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '^1.19.0'
 


### PR DESCRIPTION
## Summary
- Fix invalid SHA for `actions/setup-go@v3` that was causing CI build failures
- `be3c94b385c46ce66fc01faa1b4db15cdae82f79` → `be3c94b385c4f180051c996d336f57a34c397495`